### PR TITLE
check for resources if there are no methods

### DIFF
--- a/lib/util/extract.js
+++ b/lib/util/extract.js
@@ -30,11 +30,16 @@ function reduce(schema, parent) {
   _.each(schema.resources, function(resource) {
     var parts = parent.concat([resource.relativeUri]);
 
-    if (!(resource && resource.methods)) {
+    if (!resource) {
       return;
     }
+    var methods = [];
 
-    _.each(resource.methods, function(method) {
+    if ((resource && resource.methods)) {
+      methods = resource.methods;
+    }
+
+    _.each(methods, function(method) {
       if (!(method && method.responses)) {
         return;
       }


### PR DESCRIPTION
It's possible that a raml-file has a section without any methods but with some child resources.
In the extract module the reduce method skipped the recursion if there were no methods.
This commit fixed this issue so that reduce walks correctly through the resources tree.
