### PR TITLE
Use an older version of gaze to support node v0.12

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "cli-color-tty": "^1.0.1",
     "express": "^4.11.2",
-    "gaze": "^0.6.4",
+    "gaze": "^0.5.1",
     "json-schema-faker": "^0.1.5",
     "lodash": "^2.4.1",
     "minimist": "^1.1.0",


### PR DESCRIPTION
See https://github.com/shama/gaze/issues/175
