### PR TITLE
Fix `Error: Cannot set property '$offset' of null`

### DIFF
--- a/lib/util/extract.js
+++ b/lib/util/extract.js
@@ -63,7 +63,7 @@ function reduce(schema, parent) {
 
           // TODO: csonschema?
           var fixed_path = method.method.toUpperCase() + ' ' + route,
-              schema = parse(body.schema, fixed_path);
+              schema = parse(body.schema, fixed_path) || {};
 
           schema.$offset = hash();
 


### PR DESCRIPTION
I'm trying to define `204` response on `DELETE` method, But it will throw Error if giving an empty schema.
