### PR TITLE
Add support for alternative external type definitions

### DIFF
--- a/lib/util/extract.js
+++ b/lib/util/extract.js
@@ -40,7 +40,8 @@ function reduce(schema, parent) {
 
         _.each(_body, function(body) {
           if (!body.schemaContent) {
-            body.schemaContent = body.schema && body.schema[0];
+            body.schemaContent = (body.hasOwnProperty('type') && body.type && body.type[0]) ||
+                                 (body.hasOwnProperty('schema') && body.schema && body.schema[0]);
           }
 
           if (body.name !== 'application/json') {
@@ -86,6 +87,7 @@ module.exports = function(schema) {
       all = {};
 
   var _schemas = {};
+  var _examples = {};
 
   _.each(schema.schemas || [], function(items) {
       _.each(items, function(item, key) {
@@ -96,6 +98,7 @@ module.exports = function(schema) {
   _.each(schema.types || [], function(items) {
       _.each(items, function(item) {
         _schemas[item.name] = item.type[0];
+        _examples[item.name] = item.example;
       });
     });
 
@@ -109,7 +112,13 @@ module.exports = function(schema) {
         _key.push(_status);
 
         if (typeof body.schema === 'string') {
-          body.schema = parse(_schemas[body.schema], _key.join(' ')) || null;
+          var schema_name = body.schema;
+
+          body.schema = parse(_schemas[schema_name], _key.join(' ')) || null;
+
+          if (body.example === null) {
+            body.example = _examples[schema_name];
+          }
         }
 
         if (body.schema !== null && !all[body._ref]) {

--- a/spec/fixtures-xkcd/api2.raml
+++ b/spec/fixtures-xkcd/api2.raml
@@ -1,0 +1,31 @@
+#%RAML 1.0
+title: XKCD
+baseUri: http://xkcd.com
+types:
+  comic:
+    type: !include schemas/comic-schema.json
+    example: !include examples/comic-example.json
+/{comicId}/info.0.json:
+  uriParameters:
+    comicId:
+      type: number
+  get:
+    description: |
+      Fetch comics and metadata  by comic id.
+    responses:
+      200:
+        body:
+          application/json:
+            type: comic
+/info.0.json:
+  get:
+    description: |
+      Fetch current comic and metadata.
+    responses:
+      200:
+        body:
+          application/json:
+            type: comic
+documentation:
+  - title: Headline
+    content: !include docs/headline.md

--- a/spec/xkcd-spec.coffee
+++ b/spec/xkcd-spec.coffee
@@ -1,32 +1,36 @@
 mockServer = require('../lib/mock-server')
 fetch = require('./helpers/fetch')
 
-describe 'XKCD example', ->
-  killServer = null
+test = (raml) ->
+  describe 'XKCD example', ->
+    killServer = null
 
-  beforeEach (done) ->
-    mockServer
-      port: 9002
-      silent: true
-      raml: './spec/fixtures-xkcd/api.raml'
-      fakeroot: 'http://json-schema.org'
-      directory: './spec/fixtures-xkcd/schemas'
-    , (err, stop) ->
-      killServer = stop
-      done()
+    beforeEach (done) ->
+      mockServer
+        port: 9002
+        silent: true
+        raml: raml
+        fakeroot: 'http://json-schema.org'
+        directory: './spec/fixtures-xkcd/schemas'
+      , (err, stop) ->
+        killServer = stop
+        done()
 
-  afterEach ->
-    killServer()
+    afterEach ->
+      killServer()
 
-  describe 'making requests', ->
-    it 'should responds to /info.0.json', (done) ->
-      fetch 'http://localhost:9002/info.0.json?_forceExample=true', (err, response) ->
-       expect(response.json.safe_title).toEqual 'Morse Code'
-       expect(response.status).toBe 200
-       done()
+    describe 'making requests', ->
+      it 'should responds to /info.0.json', (done) ->
+        fetch 'http://localhost:9002/info.0.json?_forceExample=true', (err, response) ->
+         expect(response.json.safe_title).toEqual 'Morse Code'
+         expect(response.status).toBe 200
+         done()
 
-    it 'should responds to /x/info.0.json', (done) ->
-      fetch 'http://localhost:9002/x/info.0.json?_forceExample=true', (err, response) ->
-       expect(response.json.safe_title).toEqual 'Morse Code'
-       expect(response.status).toBe 200
-       done()
+      it 'should responds to /x/info.0.json', (done) ->
+        fetch 'http://localhost:9002/x/info.0.json?_forceExample=true', (err, response) ->
+         expect(response.json.safe_title).toEqual 'Morse Code'
+         expect(response.status).toBe 200
+         done()
+
+test('./spec/fixtures-xkcd/api.raml')
+test('./spec/fixtures-xkcd/api2.raml')


### PR DESCRIPTION
Support generating mockups for types defining in the following format

```
types:
  comic:
    type: !include schemas/comic-schema.json
    example: !include examples/comic-example.json
```