### PR TITLE
Support for single example or multiple examples by name

### DIFF
--- a/lib/mock-server.js
+++ b/lib/mock-server.js
@@ -97,17 +97,17 @@ module.exports = function(params, callback) {
               res.setHeader('Access-Control-Expose-Headers', 'Accept-Ranges, Content-Encoding, Content-Length, Content-Range');
 
               var reqStatus = req.query._statusCode || _.sample(keys),
-                  reqExample = req.query._forceExample === 'true' || params.forceExample
-                  reqExampleName = req.query.example || 'default';
+                  reqForceExample = req.query._forceExample === 'true' || params.forceExample,
+                  reqExample = req.query.example || 'default';
 
               try {
                 if (keys.indexOf(reqStatus) === -1) {
                   throw new Error('missing response for ' + req.url + ' (' + reqStatus + ')');
                 }
 
-                var sample = responses[reqStatus].examples[reqExampleName] || null;
+                var sample = responses[reqStatus].examples[reqExample] || null;
                 if (!sample){
-                  sample = responses[reqStatus].examples[reqExampleName];
+                  sample = responses[reqStatus].examples[reqExample];
                 }
                 var schema = api.definitions[responses[reqStatus]._ref] || null;
 
@@ -115,7 +115,7 @@ module.exports = function(params, callback) {
                   throw new Error('missing example for ' + req.url + ' (' + reqStatus + ')');
                 }
 
-                if (!reqExample) {
+                if (!reqForceExample) {
                   sample = schema ? jsonfaker(schema, refs) : sample;
                 }
 

--- a/lib/mock-server.js
+++ b/lib/mock-server.js
@@ -97,14 +97,18 @@ module.exports = function(params, callback) {
               res.setHeader('Access-Control-Expose-Headers', 'Accept-Ranges, Content-Encoding, Content-Length, Content-Range');
 
               var reqStatus = req.query._statusCode || _.sample(keys),
-                  reqExample = req.query._forceExample === 'true' || params.forceExample;
+                  reqExample = req.query._forceExample === 'true' || params.forceExample
+                  reqExampleName = req.query.example || 'default';
 
               try {
                 if (keys.indexOf(reqStatus) === -1) {
                   throw new Error('missing response for ' + req.url + ' (' + reqStatus + ')');
                 }
 
-                var sample = responses[reqStatus].example || null;
+                var sample = responses[reqStatus].examples[reqExampleName] || null;
+                if (!sample){
+                  sample = responses[reqStatus].examples[reqExampleName];
+                }
                 var schema = api.definitions[responses[reqStatus]._ref] || null;
 
                 if (!(sample || schema)) {

--- a/lib/util/extract.js
+++ b/lib/util/extract.js
@@ -60,8 +60,6 @@ function reduce(schema, parent) {
               : body.schemaContent;
           }
 
-          console.log(JSON.stringify(body.examples));
-
           var examples = {};
           if(body.examples){
             _.each(body.examples, function(example){

--- a/lib/util/extract.js
+++ b/lib/util/extract.js
@@ -60,10 +60,18 @@ function reduce(schema, parent) {
               : body.schemaContent;
           }
 
+          console.log(JSON.stringify(body.examples));
+
+          var examples = {};
+          _.each(body.examples, function(example){
+            var value = example.value;
+            examples[example.name] = typeof value === 'string' ? parse(value, fixed_path) : value || null
+          });
+
           retval[route][method.method][_status] = {
             _ref: hash(),
             schema: fixed_schema || null,
-            example: typeof body.example === 'string' ? parse(body.example, fixed_path) : body.example || null
+            examples: examples
           };
         });
       });

--- a/lib/util/extract.js
+++ b/lib/util/extract.js
@@ -63,10 +63,15 @@ function reduce(schema, parent) {
           console.log(JSON.stringify(body.examples));
 
           var examples = {};
-          _.each(body.examples, function(example){
-            var value = example.value;
-            examples[example.name] = typeof value === 'string' ? parse(value, fixed_path) : value || null
-          });
+          if(body.examples){
+            _.each(body.examples, function(example){
+              var value = example.value;
+              examples[example.name] = typeof value === 'string' ? parse(value, fixed_path) : value || null;
+            });
+          }
+          if(body.example){
+            examples['default'] = typeof body.example === 'string' ? parse(body.example, fixed_path) : body.example || null;
+          }
 
           retval[route][method.method][_status] = {
             _ref: hash(),


### PR DESCRIPTION
For this mock server to be usable with RAML specs that specify multiple examples per response it needs to be able to parse the respective RAML as well as offer a query parameter to serve the specified example.

The introduced changes are totally backwards compatible as the single example case is handled as 'default' example. There are test failures in the current master of your project, so I could not get this clean. But I had other failures while making the changes an I am pretty confident that everything should work fine.

Would be great if you could fix your master and rebase with proposed changes. Thank you!